### PR TITLE
Fix issue with fetching stream_id

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -737,7 +737,7 @@ impl SrtSocket {
     }
     pub fn get_stream_id(&self) -> Result<String> {
         let mut id = String::from_iter([' '; 512].iter());
-        let mut id_len = mem::size_of_val(&id) as i32;
+        let mut id_len = id.len() as i32;
         let result = unsafe {
             srt::srt_getsockflag(
                 self.id,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -736,7 +736,7 @@ impl SrtSocket {
         error::handle_result(state, 0)
     }
     pub fn get_stream_id(&self) -> Result<String> {
-        let mut id = String::from_iter([' '; 512].iter());
+        let mut id = String::from_iter([' '; 513].iter());
         let mut id_len = id.len() as i32;
         let result = unsafe {
             srt::srt_getsockflag(


### PR DESCRIPTION
# What

Fixes issue fetching stream_ids longer than 24 chars.

We now use the length of the actual buffer instead of the size of the string pointer (which is always 24).

We've also increased the buffer size to 513, as we need space for the max length of the stream_id (512) *and* a null terminator. Without this fix we still explode if the client sends exactly 512, but with this fix I can't make it explode using ffmpeg as a sender at least.