### PR TITLE
Log and continue on epoll error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check:
     name: Check & Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out
         uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3"
 parking_lot = "0.12.1"
 tokio = { version = "1.33.0", features = ["full"] }
 os_socketaddr = { version = "0.2.5" }
+tracing = { version = "0.1" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = {version = "0.3", features = ["winsock2"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use std::{
     sync::Arc,
     task::Waker,
     thread,
+    time::Duration,
 };
 
 pub use socket::{
@@ -825,6 +826,7 @@ impl SrtAsyncListener {
                 let res = epoll.wait(-1);
                 if let Err(err) = res {
                     error!("SRT async accept epoll wait error: {}", err);
+                    thread::sleep(Duration::from_millis(1000));
                     continue;
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,7 +820,13 @@ impl SrtAsyncListener {
         let condvar = self.condvar.clone();
 
         thread::spawn(move || {
-            while epoll.wait(-1).is_ok() {
+            loop {
+                let res = epoll.wait(-1);
+                if let Err(err) = res {
+                    eprintln!("SRT async accept epoll wait error: {}", err);
+                    continue;
+                }
+
                 let mut shared = shared.lock();
 
                 shared.has_data = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use futures::{
 };
 use parking_lot::{Condvar, Mutex};
 use srt::{SRT_EPOLL_OPT, SRT_TRACEBSTATS};
+use tracing::error;
 
 use std::{
     convert::TryInto,
@@ -823,7 +824,7 @@ impl SrtAsyncListener {
             loop {
                 let res = epoll.wait(-1);
                 if let Err(err) = res {
-                    eprintln!("SRT async accept epoll wait error: {}", err);
+                    error!("SRT async accept epoll wait error: {}", err);
                     continue;
                 }
 


### PR DESCRIPTION
The old code would exit without logging any error if an epoll error occurred.

We now instead log the error and try again.

This could help prevent a state where we cannot accept new SRT connections.